### PR TITLE
Add Particle Puzzle prototype

### DIFF
--- a/Assets/Resources/particle_config.json
+++ b/Assets/Resources/particle_config.json
@@ -1,0 +1,7 @@
+{
+    "particles": [
+        {"name": "Water", "colorHex": "#3083ff", "density": 1.0},
+        {"name": "Sand", "colorHex": "#c2b280", "density": 2.0},
+        {"name": "Stone", "colorHex": "#707070", "density": 3.0}
+    ]
+}

--- a/Assets/Scripts/Particle.cs
+++ b/Assets/Scripts/Particle.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+[RequireComponent(typeof(SpriteRenderer))]
+[RequireComponent(typeof(Rigidbody2D))]
+public class Particle : MonoBehaviour
+{
+    private Rigidbody2D _rb;
+    private SpriteRenderer _renderer;
+
+    public void Initialize(ParticleType type)
+    {
+        if (_rb == null) _rb = GetComponent<Rigidbody2D>();
+        if (_renderer == null) _renderer = GetComponent<SpriteRenderer>();
+
+        _renderer.color = type.GetColor();
+        _rb.mass = type.density;
+    }
+}

--- a/Assets/Scripts/ParticleConfig.cs
+++ b/Assets/Scripts/ParticleConfig.cs
@@ -1,0 +1,7 @@
+using System;
+
+[Serializable]
+public class ParticleConfig
+{
+    public ParticleType[] particles;
+}

--- a/Assets/Scripts/ParticleManager.cs
+++ b/Assets/Scripts/ParticleManager.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class ParticleManager : MonoBehaviour
+{
+    public TextAsset configFile;
+    private Dictionary<string, ParticleType> _types = new Dictionary<string, ParticleType>();
+
+    public IReadOnlyDictionary<string, ParticleType> Types => _types;
+
+    void Awake()
+    {
+        LoadConfig();
+    }
+
+    void LoadConfig()
+    {
+        if (configFile == null)
+        {
+            Debug.LogError("Particle config file missing");
+            return;
+        }
+
+        ParticleConfig config = JsonUtility.FromJson<ParticleConfig>(configFile.text);
+        _types.Clear();
+        foreach (var t in config.particles)
+        {
+            _types[t.name] = t;
+        }
+    }
+}

--- a/Assets/Scripts/ParticleSpawner.cs
+++ b/Assets/Scripts/ParticleSpawner.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class ParticleSpawner : MonoBehaviour
+{
+    public ParticleManager manager;
+    public Camera mainCamera;
+    public GameObject particlePrefab;
+
+    private string currentType = "Water";
+
+    void Update()
+    {
+        if (Input.GetMouseButtonDown(0))
+        {
+            SpawnParticle();
+        }
+    }
+
+    public void SetCurrentType(string type)
+    {
+        currentType = type;
+    }
+
+    void SpawnParticle()
+    {
+        if (manager == null || mainCamera == null || particlePrefab == null)
+            return;
+
+        if (!manager.Types.TryGetValue(currentType, out var type))
+            return;
+
+        Vector3 pos = mainCamera.ScreenToWorldPoint(Input.mousePosition);
+        pos.z = 0f;
+        var obj = Instantiate(particlePrefab, pos, Quaternion.identity);
+        var particle = obj.GetComponent<Particle>();
+        if (particle != null)
+        {
+            particle.Initialize(type);
+        }
+    }
+}

--- a/Assets/Scripts/ParticleType.cs
+++ b/Assets/Scripts/ParticleType.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using System;
+
+[Serializable]
+public class ParticleType
+{
+    public string name;
+    public string colorHex;
+    public float density;
+
+    public Color GetColor()
+    {
+        if (ColorUtility.TryParseHtmlString(colorHex, out var c))
+            return c;
+        return Color.white;
+    }
+}

--- a/Assets/Scripts/ParticleUI.cs
+++ b/Assets/Scripts/ParticleUI.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.Linq;
+
+public class ParticleUI : MonoBehaviour
+{
+    public ParticleManager manager;
+    public ParticleSpawner spawner;
+    public Dropdown dropdown;
+
+    void Start()
+    {
+        if (manager == null || dropdown == null)
+            return;
+
+        dropdown.ClearOptions();
+        dropdown.AddOptions(manager.Types.Keys.ToList());
+        dropdown.onValueChanged.AddListener(OnValueChanged);
+
+        // initialize selection
+        if (dropdown.options.Count > 0)
+        {
+            OnValueChanged(0);
+        }
+    }
+
+    void OnValueChanged(int index)
+    {
+        if (index < 0 || index >= dropdown.options.Count)
+            return;
+        string type = dropdown.options[index].text;
+        spawner.SetCurrentType(type);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# VibeGame
+# Particle Puzzle
+
+Particle Puzzle is a simple particle-based puzzle prototype for Unity. The project demonstrates how to configure different particle types using a JSON file and spawn them in a scene using basic physics.
+
+## Setup
+1. Open the project in Unity.
+2. Create a prefab for a particle:
+   - Add a `SpriteRenderer`, `Rigidbody2D` and `BoxCollider2D`.
+   - Assign a small sprite (e.g., a square) to the renderer.
+   - Set the prefab reference in `ParticleSpawner`.
+3. Add the **ParticleManager**, **ParticleSpawner**, and **ParticleUI** scripts to objects in your scene.
+   - Assign `particle_config.json` to the `ParticleManager`.
+   - Assign the particle prefab and main camera to `ParticleSpawner`.
+   - Create a UI `Dropdown` and connect it with `ParticleUI`.
+4. Play the scene. Select a particle type from the dropdown and click in the game view to place particles. They will fall and settle on the floor using Unity's physics.
+
+Particle properties such as color and density can be modified in `Assets/Resources/particle_config.json`.


### PR DESCRIPTION
## Summary
- set up new Unity game prototype "Particle Puzzle"
- define particle types via `ParticleType` and JSON config
- spawn particles on mouse click with physics
- dropdown UI to select particle type
- document setup steps in README

## Testing
- `ls -R | head`


------
https://chatgpt.com/codex/tasks/task_e_6860aaf963848327a91063b1a54bbd58